### PR TITLE
common: Fix log functions to report correct filename and line info

### DIFF
--- a/common/log.go
+++ b/common/log.go
@@ -1,8 +1,12 @@
 package common
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 )
 
 var (
@@ -11,30 +15,51 @@ var (
 )
 
 func init() {
-	flag := log.Ldate|log.Ltime|log.Lshortfile
+	flag := log.Ldate|log.Ltime
 	outLogger = log.New(os.Stdout, "", flag)
 	errLogger = log.New(os.Stderr, "", flag)
+}
+
+// Get the file and function information of the logger caller.
+// Result: "filename:line:function"
+func getOrigin() string {
+	// calldepth is 2: caller -> xxxPrintf() -> getOrigin()
+	pc, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return "???:0:???"
+	}
+
+	filename := file[strings.LastIndex(file, "/")+1:]
+	funcname := runtime.FuncForPC(pc).Name()
+	fn := funcname[strings.LastIndex(funcname, ".")+1:]
+	return filename + ":" + strconv.Itoa(line) + ":" + fn
 }
 
 func DebugPrintf(format string, v ...interface{}) {
 	if !AppConfig.Debug {
 		return
 	}
-	errLogger.Printf("[DEBUG] " + format, v...)
+
+	format = fmt.Sprintf("[DEBUG] %s: %s", getOrigin(), format)
+	errLogger.Printf(format, v...)
 }
 
 func InfoPrintf(format string, v ...interface{}) {
-	outLogger.Printf("[INFO] " + format, v...)
+	format = fmt.Sprintf("[INFO] %s: %s", getOrigin(), format)
+	outLogger.Printf(format, v...)
 }
 
 func WarnPrintf(format string, v ...interface{}) {
-	errLogger.Printf("[WARNING] " + format, v...)
+	format = fmt.Sprintf("[WARNING] %s: %s", getOrigin(), format)
+	errLogger.Printf(format, v...)
 }
 
 func ErrorPrintf(format string, v ...interface{}) {
-	errLogger.Printf("[ERROR] " + format, v...)
+	format = fmt.Sprintf("[ERROR] %s: %s", getOrigin(), format)
+	errLogger.Printf(format, v...)
 }
 
 func Fatalf(format string, v ...interface{}) {
-	errLogger.Fatalf("[FATAL] " + format, v...)
+	format = fmt.Sprintf("[FATAL] %s: %s", getOrigin(), format)
+	errLogger.Fatalf(format, v...)
 }


### PR DESCRIPTION
The log functions wrap around Go's builtin 'log' module.  While the latter reports the filename and line where the log messages emit, they were always the file 'log.go' and lines in it.

So implement the 'getOrigin()' function to obtain the real caller info by our own.  In addition, obtain the function name of the caller and report in the log messages.

Credit: https://stackoverflow.com/a/58232098