### PR TITLE
chore: Add '-trimpath' build option and refactor Makefile.inc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.log
 *.mmdb
-/main
 /mirrorselect
+/mirrorselect-*-*

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -21,5 +21,5 @@ test: dbip
 
 dbip: testdata/dbip-city-lite.mmdb
 testdata/dbip-city-lite.mmdb:
-	curl https://download.db-ip.com/free/dbip-city-lite-2023-03.mmdb.gz | \
+	curl https://download.db-ip.com/free/dbip-city-lite-2024-08.mmdb.gz | \
 		gunzip > $@

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,16 +1,20 @@
-MODULE=	github.com/DragonFlyBSD/mirrorselect
+PROG=		mirrorselect
+MODULE=		github.com/DragonFlyBSD/$(PROG)
+
+BUILD_ARGS+=	-trimpath -ldflags "$(LDFLAGS)"
 
 all:
-	CGO_ENABLED=0 go build -ldflags="$(LDFLAGS)" -o mirrorselect main.go
+	env CGO_ENABLED=0 \
+		go build $(BUILD_ARGS) -o $(PROG)
 
 ci: all
-	CGO_ENABLED=0 GOOS=dragonfly GOARCH=amd64 \
-		    go build -ldflags="$(LDFLAGS)" -o mirrorselect main.go
-	CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 \
-		    go build -ldflags="$(LDFLAGS)" -o mirrorselect main.go
+	env CGO_ENABLED=0 GOOS=dragonfly GOARCH=amd64 \
+		go build $(BUILD_ARGS) -o $(PROG)-dragonfly-amd64
+	env CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 \
+		go build $(BUILD_ARGS) -o $(PROG)-freebsd-amd64
 
 clean:
-	rm -f mirrorselect
+	rm -f $(PROG) $(PROG)-*-*
 
 test: dbip
 	go test -v ./common ./geoip ./monitor ./workerpool


### PR DESCRIPTION
- Add '-trimpath' option to build, so that the absolute full source paths are not included in the binary, which makes it more reproducible.  In addition, we can later make the log messages print the full file paths instead of the final file names.

- Refactor the Makefile.inc to clean up a bit.

- Update the .gitignore accordingly.